### PR TITLE
pref: implement batch processing for device commands

### DIFF
--- a/script/test_discovery_to_connect.py
+++ b/script/test_discovery_to_connect.py
@@ -81,6 +81,13 @@ async def test_discover_and_connect():
                 device["channel"], device["address"]
             )
 
+        # Test readDev
+        _LOGGER.info("Testing readDev...")
+        for device in devices:
+            gateway.command_read_dev(
+                device["dev_type"], device["channel"], device["address"]
+            )
+
         # Test group discovery
         _LOGGER.info("Testing group discovery...")
         groups = await gateway.discover_groups()


### PR DESCRIPTION
implement batch processing for device commands

- Add batch processing for `writeDev` and `readDev` commands to reduce MQTT message overhead.
- Introduce a time window (`_window_ms`) to accumulate requests before sending them as a batch.
- Implement `add_request` and `_flush_batch` methods to manage pending requests and send batched data.
- Update `searchStatus` handling in device discovery to set completion based on specific status codes.
- Enhance test script to include `readDev` command testing during discovery and connection.
 
This change improves the efficiency of command handling by grouping multiple device requests into a single MQTT message, reducing network load.