### PR TITLE
Fix discovery protocol and gateway commands format

### DIFF
--- a/PySrDaliGateway/discovery.py
+++ b/PySrDaliGateway/discovery.py
@@ -84,7 +84,7 @@ class MessageCryptor:
         cmd = self.encrypt_data(combined_data, self.SR_KEY)
         message_dict = {"cmd": cmd, "type": "HA"}
         if gw_sn:
-            message_dict["gwSn"] = gw_sn
+            message_dict["snList"] = [gw_sn]
 
         _LOGGER.debug("Prepared discovery message: %s", message_dict)
         message_json = json.dumps(message_dict)

--- a/PySrDaliGateway/gateway.py
+++ b/PySrDaliGateway/gateway.py
@@ -120,7 +120,7 @@ class DaliGateway:
 
         self._mqtt_client.publish(self._pub_topic, json.dumps(command))
 
-        _LOGGER.debug("Gateway %s: Sent batch readDev %s", self._gw_sn, command)
+        _LOGGER.debug("Gateway %s: Sent batch %s %s", self._gw_sn, cmd, json.dumps(command))
 
         self._pending_requests[cmd].clear()
         self._batch_timer.pop(cmd)
@@ -863,6 +863,7 @@ class DaliGateway:
             "devType": dev_type,
             "channel": channel,
             "address": address,
+            "fromBus": True,
         }
         command_json = json.dumps(command)
         self._mqtt_client.publish(self._pub_topic, command_json)
@@ -874,12 +875,19 @@ class DaliGateway:
             "cmd": "setDevParam",
             "msgId": str(int(time.time())),
             "gwSn": self._gw_sn,
-            "devType": dev_type,
-            "channel": channel,
-            "address": address,
-            "paramer": {
-                "maxBrightness": param["max_brightness"],
-            },
+            "data": [
+                {
+                    "devType": dev_type,
+                    "channel": channel,
+                    "address": address,
+                    "paramer": {
+                        "maxBrightness": param["max_brightness"],
+                    },
+                }
+            ],
         }
         command_json = json.dumps(command)
+        _LOGGER.debug(
+            "Gateway %s: Sending setDevParam command: %s", self._gw_sn, command
+        )
         self._mqtt_client.publish(self._pub_topic, command_json)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ python script/test_discovery_to_connect.py --device-limit 5
 ```
 
 Available tests:
+
 - `discovery` - Discover DALI gateways on network
 - `connection` - Connect to discovered gateway
 - `version` - Get gateway firmware version


### PR DESCRIPTION
## Summary
• Fix discovery message format to use snList array instead of gwSn field
• Fix addDev command to include missing fromBus parameter
• Fix setDevParam command structure to use proper data array format  
• Enhance test script with comprehensive setDevParam testing

## Test plan
- [x] Manual testing with physical DALI gateway
- [x] Verify discovery protocol changes work correctly
- [x] Test setDevParam command with maxBrightness parameter
- [x] Validate addDev command includes fromBus parameter