### PR TITLE
fix: prevent property data loss in batched MQTT requests

### DIFF
--- a/PySrDaliGateway/__version__.py
+++ b/PySrDaliGateway/__version__.py
@@ -1,4 +1,4 @@
 """Version information for PySrDaliGateway."""
 # pylint: disable=invalid-name
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/PySrDaliGateway/gateway.py
+++ b/PySrDaliGateway/gateway.py
@@ -98,6 +98,19 @@ class DaliGateway:
             self._pending_requests[cmd] = {}
 
         device_key = self._get_device_key(dev_type, channel, address)
+
+        # Merge properties instead of overwriting the entire data
+        if device_key in self._pending_requests[cmd]:
+            existing_data = self._pending_requests[cmd][device_key]
+            if "property" in existing_data and "property" in data:
+                # Merge properties, avoiding duplicates by dpid
+                existing_properties = {
+                    prop["dpid"]: prop for prop in existing_data["property"]
+                }
+                new_properties = {prop["dpid"]: prop for prop in data["property"]}
+                existing_properties.update(new_properties)
+                data["property"] = list(existing_properties.values())
+
         self._pending_requests[cmd][device_key] = data
 
         if self._batch_timer.get(cmd) is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PySrDaliGateway"
-version = "0.6.3"
+version = "0.6.4"
 description = "Python library for Sunricher DALI Gateway (EDA)"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary

- Fix property data loss when multiple requests for the same device are batched together
- Merge device properties by dpid instead of overwriting the entire data structure  
- Ensure all device properties are preserved in batched MQTT requests

## Test plan

- [x] Type checking passes (mypy)
- [x] Unit tests pass (pytest)
- [x] Linting passes (ruff)
- [ ] Manual testing with physical DALI gateway to verify property preservation in batched requests