### PR TITLE
refactor: project code review improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,11 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: script/run_pytest_changed.sh
+        language: script
+        files: ^(PySrDaliGateway|tests)/.*\.py$
+        pass_filenames: true

--- a/PySrDaliGateway/device.py
+++ b/PySrDaliGateway/device.py
@@ -147,14 +147,14 @@ class Device(DaliObjectBase):
     ) -> None:
         properties = [self._create_property(DPID_POWER, "bool", True)]
 
-        if brightness:
+        if brightness is not None:
             properties.append(
                 self._create_property(
                     DPID_BRIGHTNESS, "uint16", brightness * 1000 / 255
                 )
             )
 
-        if color_temp_kelvin:
+        if color_temp_kelvin is not None:
             properties.append(
                 self._create_property(DPID_COLOR_TEMP, "uint16", color_temp_kelvin)
             )

--- a/PySrDaliGateway/discovery.py
+++ b/PySrDaliGateway/discovery.py
@@ -57,7 +57,7 @@ class DaliGatewayDiscovery:
         message: bytes,
         gw_sn: str | None = None,
     ) -> List[DaliGateway]:
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         first_gateway_found = asyncio.Event()
         unique_gateways: List[DaliGateway] = []
         seen_sns: Set[str] = set()
@@ -91,7 +91,7 @@ class DaliGatewayDiscovery:
         start_time: float,
     ) -> None:
         while not first_gateway_found.is_set():
-            if asyncio.get_event_loop().time() - start_time >= self.DISCOVERY_TIMEOUT:
+            if asyncio.get_running_loop().time() - start_time >= self.DISCOVERY_TIMEOUT:
                 _LOGGER.info(
                     "Discovery timeout reached after %.1f seconds",
                     self.DISCOVERY_TIMEOUT,
@@ -118,7 +118,7 @@ class DaliGatewayDiscovery:
         gw_sn: str | None = None,
     ) -> None:
         while not first_gateway_found.is_set():
-            if asyncio.get_event_loop().time() - start_time >= self.DISCOVERY_TIMEOUT:
+            if asyncio.get_running_loop().time() - start_time >= self.DISCOVERY_TIMEOUT:
                 break
 
             addr = None

--- a/PySrDaliGateway/gateway.py
+++ b/PySrDaliGateway/gateway.py
@@ -1,6 +1,7 @@
 """Dali Gateway"""
 
 import asyncio
+import contextlib
 from enum import Enum, auto
 import json
 import logging
@@ -163,7 +164,9 @@ class DaliGateway:
         self._scenes_result: list[Scene] = []
         self._groups_result: list[Group] = []
         self._devices_result: list[Device] = []
+        self._devices_seen_ids: set[str] = set()
         self._bus_scan_result: list[Device] = []
+        self._bus_scan_seen_ids: set[str] = set()
         self._bus_scan_cancelled = False
         self._bus_scan_channels: list[int] = []
         self._bus_scanning = False
@@ -187,7 +190,6 @@ class DaliGateway:
             CallbackEventType.SENSOR_PARAM: {},
         }
 
-        self._window_ms = 100
         self._pending_requests: Dict[str, Dict[str, Dict[str, Any]]] = {}
         self._batch_timer: Dict[str, asyncio.TimerHandle] = {}  # cmd -> timer
 
@@ -198,6 +200,32 @@ class DaliGateway:
         ] = {}
         self._callback_lock = threading.Lock()
         self._batch_scheduled = False
+
+        # MQTT command dispatch table (built once, not per-message)
+        self._command_handlers: Dict[str, Callable[[Dict[str, Any]], None]] = {
+            "devStatus": self._process_device_status,
+            "readDevRes": self._process_device_status,
+            "writeDevRes": self._noop_handler,
+            "writeGroupRes": self._noop_handler,
+            "writeSceneRes": self._noop_handler,
+            "onlineStatus": self._process_online_status,
+            "reportEnergy": self._process_energy_report,
+            "searchDevRes": self._process_search_device_response,
+            "getSceneRes": self._process_get_scene_response,
+            "getGroupRes": self._process_get_group_response,
+            "getVersionRes": self._process_get_version_response,
+            "readGroupRes": self._process_read_group_response,
+            "readSceneRes": self._process_read_scene_response,
+            "restartGatewayRes": self._process_restart_gateway_response,
+            "getEnergyRes": self._process_get_energy_response,
+            "setSensorOnOffRes": self._noop_handler,
+            "getSensorOnOffRes": self._process_get_sensor_on_off_response,
+            "setSensorArgvRes": self._noop_handler,
+            "getSensorArgvRes": self._process_get_sensor_argv_response,
+            "setDevParamRes": self._noop_handler,
+            "getDevParamRes": self._process_get_dev_param_response,
+            "identifyDevRes": self._process_identify_dev_response,
+        }
 
     def _get_device_key(self, dev_type: str, channel: int, address: int) -> str:
         return f"{dev_type}_{channel}_{address}"
@@ -239,7 +267,7 @@ class DaliGateway:
                 self._flush_batch(cmd)
                 return
             self._batch_timer[cmd] = self._loop.call_later(
-                self._window_ms / 1000.0, self._flush_batch, cmd
+                INBOUND_CALLBACK_BATCH_WINDOW_MS / 1000.0, self._flush_batch, cmd
             )
 
     def _flush_batch(self, cmd: str) -> None:
@@ -369,7 +397,13 @@ class DaliGateway:
         if dev_id not in self._device_listeners[event_type]:
             self._device_listeners[event_type][dev_id] = []
         self._device_listeners[event_type][dev_id].append(listener)
-        return lambda: self._device_listeners[event_type][dev_id].remove(listener)
+
+        def _unsubscribe() -> None:
+            listeners = self._device_listeners.get(event_type, {}).get(dev_id, [])
+            with contextlib.suppress(ValueError):
+                listeners.remove(listener)
+
+        return _unsubscribe
 
     def _notify_listeners(
         self,
@@ -550,32 +584,7 @@ class DaliGateway:
                 )
                 return
 
-            command_handlers: Dict[str, Callable[[Dict[str, Any]], None]] = {
-                "devStatus": self._process_device_status,
-                "readDevRes": self._process_device_status,
-                "writeDevRes": self._noop_handler,
-                "writeGroupRes": self._noop_handler,
-                "writeSceneRes": self._noop_handler,
-                "onlineStatus": self._process_online_status,
-                "reportEnergy": self._process_energy_report,
-                "searchDevRes": self._process_search_device_response,
-                "getSceneRes": self._process_get_scene_response,
-                "getGroupRes": self._process_get_group_response,
-                "getVersionRes": self._process_get_version_response,
-                "readGroupRes": self._process_read_group_response,
-                "readSceneRes": self._process_read_scene_response,
-                "restartGatewayRes": self._process_restart_gateway_response,
-                "getEnergyRes": self._process_get_energy_response,
-                "setSensorOnOffRes": self._noop_handler,
-                "getSensorOnOffRes": self._process_get_sensor_on_off_response,
-                "setSensorArgvRes": self._noop_handler,
-                "getSensorArgvRes": self._process_get_sensor_argv_response,
-                "setDevParamRes": self._noop_handler,
-                "getDevParamRes": self._process_get_dev_param_response,
-                "identifyDevRes": self._process_identify_dev_response,
-            }
-
-            handler = command_handlers.get(cmd)
+            handler = self._command_handlers.get(cmd)
             if handler:
                 handler(payload_json)
             else:
@@ -771,10 +780,13 @@ class DaliGateway:
         )
 
     @staticmethod
-    def _append_unique(device: Device, result: list[Device]) -> bool:
+    def _append_unique(
+        device: Device, result: list[Device], seen_ids: set[str]
+    ) -> bool:
         """Append device to result list if unique_id is not already present."""
-        if any(existing.unique_id == device.unique_id for existing in result):
+        if device.unique_id in seen_ids:
             return False
+        seen_ids.add(device.unique_id)
         result.append(device)
         return True
 
@@ -796,7 +808,9 @@ class DaliGateway:
                 count_before = len(self._bus_scan_result)
                 for raw in payload_json.get("data", []):
                     self._append_unique(
-                        self._parse_device_from_raw(raw), self._bus_scan_result
+                        self._parse_device_from_raw(raw),
+                        self._bus_scan_result,
+                        self._bus_scan_seen_ids,
                     )
                 _LOGGER.info(
                     "Gateway %s: Received %d devices (total: %d)",
@@ -822,7 +836,9 @@ class DaliGateway:
             # Legacy exited mode - original behavior
             for raw in payload_json.get("data", []):
                 self._append_unique(
-                    self._parse_device_from_raw(raw), self._devices_result
+                    self._parse_device_from_raw(raw),
+                    self._devices_result,
+                    self._devices_seen_ids,
                 )
 
             if search_status in {0, 1}:
@@ -1503,6 +1519,7 @@ class DaliGateway:
     async def discover_devices(self) -> list[Device]:
         self._devices_received = asyncio.Event()
         self._devices_result.clear()
+        self._devices_seen_ids.clear()
         search_payload = {
             "cmd": "searchDev",
             "searchFlag": "exited",
@@ -1545,6 +1562,7 @@ class DaliGateway:
         """
         self._bus_scan_complete = asyncio.Event()
         self._bus_scan_result.clear()
+        self._bus_scan_seen_ids.clear()
         self._bus_scan_cancelled = False
         self._bus_scanning = True
         self._bus_scan_channels = channels
@@ -1578,6 +1596,7 @@ class DaliGateway:
             )
             # Discard partial results on timeout
             self._bus_scan_result.clear()
+            self._bus_scan_seen_ids.clear()
             self._bus_scanning = False
             raise
 
@@ -1588,6 +1607,7 @@ class DaliGateway:
             _LOGGER.info("Gateway %s: Bus scan was cancelled", self._gw_sn)
             # Discard partial results on cancellation
             self._bus_scan_result.clear()
+            self._bus_scan_seen_ids.clear()
             raise BusScanCancelledError(
                 f"Bus scan cancelled for gateway {self._gw_sn}",
                 gw_sn=self._gw_sn,

--- a/PySrDaliGateway/group.py
+++ b/PySrDaliGateway/group.py
@@ -89,14 +89,14 @@ class Group(DaliObjectBase):
             self._create_property(DPID_POWER, "bool", True)
         ]
 
-        if brightness:
+        if brightness is not None:
             properties.append(
                 self._create_property(
                     DPID_BRIGHTNESS, "uint16", brightness * 1000 / 255
                 )
             )
 
-        if color_temp_kelvin:
+        if color_temp_kelvin is not None:
             properties.append(
                 self._create_property(DPID_COLOR_TEMP, "uint16", color_temp_kelvin)
             )

--- a/PySrDaliGateway/helper.py
+++ b/PySrDaliGateway/helper.py
@@ -177,19 +177,19 @@ def parse_panel_status(property_list: List[Dict[str, Any]]) -> List[PanelStatus]
     return panel_events
 
 
+_MOTION_STATE_MAP: Dict[int, MotionState] = {
+    1: MotionState.NO_MOTION,
+    2: MotionState.MOTION,
+    3: MotionState.VACANT,
+    4: MotionState.OCCUPANCY,
+    5: MotionState.PRESENCE,
+}
+
+
 def parse_motion_status(property_list: List[Dict[str, Any]]) -> List[MotionStatus]:
     """Parse raw property list into MotionStatus objects for motion sensor devices"""
 
     motion_events: List[MotionStatus] = []
-
-    # Motion state mapping based on dpid values
-    motion_map = {
-        1: MotionState.NO_MOTION,
-        2: MotionState.MOTION,
-        3: MotionState.VACANT,
-        4: MotionState.OCCUPANCY,
-        5: MotionState.PRESENCE,
-    }
 
     for prop in property_list:
         dpid = prop.get("dpid")
@@ -197,7 +197,7 @@ def parse_motion_status(property_list: List[Dict[str, Any]]) -> List[MotionStatu
         if dpid is None:
             continue
 
-        motion_state = motion_map.get(dpid)
+        motion_state = _MOTION_STATE_MAP.get(dpid)
         if motion_state is None:
             # Default to no_motion for unknown dpid values
             motion_state = MotionState.NO_MOTION

--- a/script/run_pytest_changed.sh
+++ b/script/run_pytest_changed.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Pre-commit hook: run pytest only on changed files.
+#
+# - test file changed        → run that test file
+# - source / infra changed   → run all tests
+
+test_files=()
+run_all=false
+
+for f in "$@"; do
+    case "$f" in
+        tests/test_*.py)
+            test_files+=("$f") ;;
+        PySrDaliGateway/* | tests/conftest.py | tests/helpers.py | tests/cache.py)
+            run_all=true ;;
+    esac
+done
+
+if $run_all; then
+    exec pytest tests/
+elif (( ${#test_files[@]} )); then
+    exec pytest "${test_files[@]}"
+fi

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Sequence, Tuple
 import psutil
 
 from PySrDaliGateway.gateway import DaliGateway
+from PySrDaliGateway.types import LightStatus
 from PySrDaliGateway.udp_client import MessageCryptor, MulticastSender
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,7 +77,7 @@ class IdentifyResponseListener:
         if self._listen_sock is None:
             return
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         while not self._response_received.is_set():
             try:
@@ -182,3 +183,16 @@ class TestDaliGateway(DaliGateway):
             return False
         else:
             return self._identify_ack
+
+
+def make_light_callback(
+    device_id: str,
+    events: List[Tuple[str, LightStatus]],
+):
+    """Create a light status callback that appends to *events*."""
+
+    def on_light_status(status: LightStatus) -> None:
+        events.append((device_id, status))
+        _LOGGER.info("Light status: %s -> %s", device_id, status)
+
+    return on_light_status

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,6 +5,7 @@ import logging
 from typing import List, Tuple
 
 from PySrDaliGateway.device import Device
+from PySrDaliGateway.helper import is_light_device
 from PySrDaliGateway.types import (
     CallbackEventType,
     IlluminanceStatus,
@@ -14,7 +15,7 @@ from PySrDaliGateway.types import (
     PanelStatus,
 )
 
-from .helpers import TestDaliGateway
+from .helpers import TestDaliGateway, make_light_callback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,19 +23,6 @@ _LOGGER = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Callback factories
 # ---------------------------------------------------------------------------
-
-
-def _make_light_callback(
-    device_id: str,
-    events: List[Tuple[str, LightStatus]],
-):
-    """Create a light status callback that appends to *events*."""
-
-    def on_light_status(status: LightStatus) -> None:
-        events.append((device_id, status))
-        _LOGGER.info("Light status: %s -> %s", device_id, status)
-
-    return on_light_status
 
 
 def _make_motion_callback(
@@ -112,11 +100,7 @@ async def test_callback_setup(
     panel_status_events: List[Tuple[str, PanelStatus]] = []
 
     # Classify devices by type
-    light_devices = [
-        d
-        for d in discovered_devices
-        if d.dev_type in ["0101", "0102", "0103", "0104", "0105"]
-    ]
+    light_devices = [d for d in discovered_devices if is_light_device(d.dev_type)]
     motion_devices = [d for d in discovered_devices if d.dev_type == "0201"]
     illuminance_devices = [d for d in discovered_devices if d.dev_type == "0301"]
     panel_devices = [
@@ -137,7 +121,7 @@ async def test_callback_setup(
         for device in light_devices[:3]:
             device.register_listener(
                 CallbackEventType.LIGHT_STATUS,
-                _make_light_callback(device.dev_id, light_status_events),
+                make_light_callback(device.dev_id, light_status_events),
             )
             model_info = device.model or "N/A"
             _LOGGER.info(

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -10,7 +10,7 @@ from typing import List, Tuple
 import pytest
 
 from PySrDaliGateway.device import Device
-from PySrDaliGateway.helper import is_cct_device, is_light_device
+from PySrDaliGateway.helper import is_cct_device, is_light_device, is_sensor_device
 from PySrDaliGateway.types import CallbackEventType, DeviceParamType, SensorParamType
 
 from .helpers import TestDaliGateway
@@ -132,7 +132,7 @@ async def test_set_dev_param(
 
     # Find a light device to test
     light_device = next(
-        (d for d in discovered_devices if d.dev_type.startswith("01")), None
+        (d for d in discovered_devices if is_light_device(d.dev_type)), None
     )
     assert light_device is not None, "No light device found for parameter testing"
 
@@ -354,7 +354,7 @@ async def test_set_sensor_param(
 
     # Find a sensor device to test
     sensor_device = next(
-        (d for d in discovered_devices if d.dev_type.startswith("02")), None
+        (d for d in discovered_devices if is_sensor_device(d.dev_type)), None
     )
 
     if not sensor_device:

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -10,7 +10,7 @@ from PySrDaliGateway.device import Device
 from PySrDaliGateway.group import Group
 from PySrDaliGateway.types import CallbackEventType, LightStatus
 
-from .helpers import TestDaliGateway
+from .helpers import TestDaliGateway, make_light_callback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,19 +36,6 @@ def _find_member_device_ids(
                 member_ids.append(dev.dev_id)
                 break
     return member_ids
-
-
-def _make_light_callback(
-    device_id: str,
-    events: List[Tuple[str, LightStatus]],
-):
-    """Create a light status callback that appends to *events*."""
-
-    def on_light_status(status: LightStatus) -> None:
-        events.append((device_id, status))
-        _LOGGER.info("Light status: %s -> %s", device_id, status)
-
-    return on_light_status
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +150,7 @@ async def test_group_control(
         if dev.dev_id in member_device_ids:
             dev.register_listener(
                 CallbackEventType.LIGHT_STATUS,
-                _make_light_callback(dev.dev_id, light_status_events),
+                make_light_callback(dev.dev_id, light_status_events),
             )
 
     # --- Test 1: Turn on with brightness ---
@@ -326,7 +313,7 @@ async def test_group_brightness(
         if dev.dev_id in member_device_ids:
             dev.register_listener(
                 CallbackEventType.LIGHT_STATUS,
-                _make_light_callback(dev.dev_id, light_status_events),
+                make_light_callback(dev.dev_id, light_status_events),
             )
 
     # Turn on the group first


### PR DESCRIPTION
## Summary

Full project code review — test cleanup, bug fixes, performance improvements, and code quality.

### Test cleanup
- Extract duplicated `_make_light_callback` to `tests/helpers.py` as shared `make_light_callback()`
- Replace raw `dev_type.startswith("01"/"02")` with `is_light_device()` / `is_sensor_device()`
- Replace hardcoded light type list in `test_callbacks.py` with `is_light_device()`
- Fix deprecated `asyncio.get_event_loop()` → `get_running_loop()` in `tests/helpers.py`

### Pre-commit hook
- Add pytest pre-commit hook with incremental test selection
- Test file changed → run only that test file
- Source or test infra changed → run all tests

### Bug fixes
- **`brightness=0` silently ignored** — `Device.turn_on()` and `Group.turn_on()` used `if brightness:` which drops falsy values. Changed to `if brightness is not None:`. Same fix for `color_temp_kelvin`.
- **Listener unsubscribe crash** — double-call raised `ValueError`. Now uses `contextlib.suppress(ValueError)`.

### Performance
- **`command_handlers` dict rebuilt per MQTT message** — moved 20-entry dispatch dict from `_on_message()` to `__init__` (built once).
- **O(n) device deduplication → O(1)** — `_append_unique()` now uses a `set[str]` instead of linear scan.
- **`motion_map` dict rebuilt per call** — moved to module-level constant `_MOTION_STATE_MAP`.

### Cleanup
- Replace deprecated `asyncio.get_event_loop()` with `get_running_loop()` in `discovery.py` (3 sites)
- Remove redundant `_window_ms`, use existing `INBOUND_CALLBACK_BATCH_WINDOW_MS` constant

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] Pre-commit hooks pass
- [x] Hardware integration tests: 19 passed, 1 skipped, 4 deselected (135s)